### PR TITLE
File names with spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # nemo-action-copy-filepath-to-clipboard
 Custom context menu action for Nemo file manager
 # Installation
- _Installation was tested on Linux Mint 19.1_.
+ _Installation was tested on Linux Mint 19.1 and Ubuntu 20.04_.
  _Requires root access_
 * Install xclip (sudo apt-get install xclip)
-* Copy __copy-filepath-to-clipboard.nemo_action__ and __copy-filepath-to-clipboard.sh__ to /usr/share/nemo/actions
+* Copy __copy-filepath-to-clipboard.nemo_action__, __copy-quoted-filepath-to-clipboard.nemo_action__ and __copy-filepath-to-clipboard.sh__ to /usr/share/nemo/actions

--- a/copy-filepath-to-clipboard.sh
+++ b/copy-filepath-to-clipboard.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo -n $1 | xclip -selection clipboard
+echo -n $@ | xclip -selection clipboard

--- a/copy-quoted-filepath-to-clipboard.nemo_action
+++ b/copy-quoted-filepath-to-clipboard.nemo_action
@@ -1,0 +1,9 @@
+[Nemo Action]
+
+Active=true
+Name=Copy filepath with quotes
+Comment=Action to copy filepath to clipboard
+Exec=<copy-filepath-to-clipboard.sh \"%F\">
+Icon-Name=gtk-execute
+Selection=s
+Extensions=any


### PR DESCRIPTION
Taking [this](https://unix.stackexchange.com/a/197099/460903) suggestion, the plugin would now work for filepaths with spaces.